### PR TITLE
perf: enable edge/CDN caching to cut Vercel usage

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -46,19 +46,6 @@ const nextConfig: NextConfig = {
     dangerouslyAllowSVG: false,
     contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
   },
-  async headers() {
-    return [
-      {
-        source: '/:path*',
-        headers: [
-          {
-            key: 'Cache-Control',
-            value: 'no-store, max-age=0',
-          },
-        ],
-      },
-    ]
-  },
 }
 
 export default withSerwist(nextConfig)

--- a/src/app/api/fallback-image/route.ts
+++ b/src/app/api/fallback-image/route.ts
@@ -84,7 +84,7 @@ export async function GET(request: NextRequest) {
     status: 200,
     headers: {
       'Content-Type': 'image/webp',
-      'Cache-Control': 'public, max-age=600, s-maxage=1800, stale-while-revalidate=86400',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600, stale-while-revalidate=86400',
     },
   })
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,7 @@ import generateSEOMetadata from '@/shared/helpers/generateSEOMetadata'
 import { getRainChartDataForRegion } from '@/shared/helpers/v2/dataSource/getWeatherChartData'
 import { findRegionByCode } from '@/shared/types/region'
 
-export const dynamic = 'force-dynamic'
+export const revalidate = 3600
 
 export async function generateMetadata(): Promise<Metadata> {
   // read route params

--- a/src/app/radar/[code]/page.tsx
+++ b/src/app/radar/[code]/page.tsx
@@ -10,7 +10,7 @@ import { isRadarCode } from '@/shared/types/radarRegions'
 type Props = {
   params: Promise<{ code: string }>
 }
-export const dynamic = 'force-dynamic'
+export const revalidate = 3600
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   // read route params

--- a/src/app/regions/[name]/page.tsx
+++ b/src/app/regions/[name]/page.tsx
@@ -7,7 +7,7 @@ import generateSEOMetadata from '@/shared/helpers/generateSEOMetadata'
 import { getRainChartDataForRegion } from '@/shared/helpers/v2/dataSource/getWeatherChartData'
 import { findRegionByCode } from '@/shared/types/region'
 
-export const dynamic = 'force-dynamic'
+export const revalidate = 3600
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const params = await props.params

--- a/src/app/satellite/page.tsx
+++ b/src/app/satellite/page.tsx
@@ -6,7 +6,7 @@ import { config } from '@/config'
 import generateSEOMetadata from '@/shared/helpers/generateSEOMetadata'
 import { getSatelliteChartData } from '@/shared/helpers/v2/dataSource/getWeatherChartData'
 
-export const dynamic = 'force-dynamic'
+export const revalidate = 3600
 
 export const generateMetadata = async (): Promise<Metadata> =>
   generateSEOMetadata({

--- a/src/app/upperair/[[...balloon]]/page.tsx
+++ b/src/app/upperair/[[...balloon]]/page.tsx
@@ -7,7 +7,7 @@ import generateSEOMetadata from '@/shared/helpers/generateSEOMetadata'
 import { getUpperAirChartDataForCode } from '@/shared/helpers/v2/dataSource/getWeatherChartData'
 import { getsBalloonLocationCodeOrDefault } from '@/shared/types/balloonLocations'
 
-export const dynamic = 'force-dynamic'
+export const revalidate = 3600
 
 export async function generateMetadata(props: Props): Promise<Metadata> {
   const params = await props.params

--- a/src/shared/helpers/v2/screenScraper/loadImages.ts
+++ b/src/shared/helpers/v2/screenScraper/loadImages.ts
@@ -11,6 +11,7 @@ export async function loadImages(
     const timeoutId = setTimeout(() => controller.abort(), 10000)
     const response = await fetch(new URL(url, config.metvuwBaseUrl).href, {
       signal: controller.signal,
+      next: { revalidate: 3600 },
     })
     clearTimeout(timeoutId)
     const rawHtml = await response.text()

--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,1 @@
-{
-  "crons": [
-    {
-      "path": "/api/cache/refresh",
-      "schedule": "0 7 * * *"
-    },
-    {
-      "path": "/api/cache/refresh",
-      "schedule": "0 8 * * *"
-    }
-  ]
-}
+{}


### PR DESCRIPTION
## Why

On the Vercel free plan and rate-limited. Over/near quota on Function Duration, Function Invocations, Edge Requests, and Fast Origin Transfer.

**Root cause:** `next.config.ts` set a global `Cache-Control: no-store` on `/:path*`, which also matched `/api/fallback-image` and **overrode that route's own cache header**. The CDN was forbidden from caching anything, so every weather-image view re-downloaded from metvuw.com and re-ran `sharp`, and every page view re-scraped + re-rendered.

Production runs direct source mode (`METVUW_DIRECT_SOURCE_MODE=true`), so this hit every request.

## Changes

1. **Remove the global `no-store` header** (`next.config.ts`) — the main leak.
2. **Image proxy CDN cache → 1h** (`src/app/api/fallback-image/route.ts`): `s-maxage=3600`.
3. **Pages: `force-dynamic` → `revalidate = 3600`** (5 page files) — 1h ISR.
4. **Scraper fetch ISR-cacheable** (`loadImages.ts`): `next: { revalidate: 3600 }` so the no-store default doesn't force pages dynamic.
5. **Remove dead cron** (`vercel.json`): both entries pointed at non-existent `/api/cache/refresh` (404'd twice daily).

## Effect

- Each weather image is transformed at most once/hour, then served from edge — cuts **Function Duration / Invocations / Fast Origin Transfer**.
- Pages scrape + render at most once/hour/route instead of per request — cuts **Edge Requests / Function Invocations/Duration**.

Build confirms `/` and `/satellite` now prerender static with 1h revalidate; dynamic-param routes (`radar`, `regions`, `upperair`) are ISR-cached on demand.

## Note on Image Optimization quota

`images.unoptimized: true` is already set and there's no `next/image` usage, so no new transforms are possible — those counters are residual and should plateau. No code change.

## Verify after deploy

- Hit a weather image twice: response header `s-maxage=3600` (not `no-store`), `x-vercel-cache: HIT` on the 2nd.
- Watch the Vercel usage dashboard over 24–48h for the drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)